### PR TITLE
Make app blocking work on Linux and macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,6 +1354,8 @@ dependencies = [
  "focuser-app",
  "focuser-common",
  "focuser-core",
+ "objc2-app-kit",
+ "objc2-core-graphics",
  "serde",
  "serde_json",
  "specta",
@@ -1371,6 +1373,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "windows 0.58.0",
+ "x11rb",
 ]
 
 [[package]]
@@ -1645,6 +1648,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2764,6 +2777,7 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -6650,6 +6664,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a8885a854a8bfdf87a301e53e41b17c5f8f33639903131338b997b1eb614f44"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf4d1bc32aa46eec18caa634ec3cf4c05bfa151f12b93b510b15190f69a1ca8"
 
 [[package]]
 name = "xattr"

--- a/crates/focuser-app/src/command.rs
+++ b/crates/focuser-app/src/command.rs
@@ -312,6 +312,9 @@ pub struct BlockingHealth {
     /// A keyword, wildcard or URL-path rule is active. Only the extension can
     /// enforce those; a hosts file has no way to express them.
     pub extension_only_rules: bool,
+    /// This session can report which app is in front, so app allowances can
+    /// count down. False on Wayland, which has no such protocol.
+    pub app_usage_measurable: bool,
 }
 
 impl BlockingHealth {
@@ -475,6 +478,7 @@ mod health_tests {
             extension_connected,
             hosts_writable,
             extension_only_rules: false,
+            app_usage_measurable: true,
         }
     }
 

--- a/crates/focuser-app/src/execute.rs
+++ b/crates/focuser-app/src/execute.rs
@@ -372,6 +372,7 @@ pub fn execute(ctx: &AppContext, cmd: Command) -> CommandOutcome<CommandResult> 
                 extension_connected: !ctx.connected_browsers().is_empty(),
                 hosts_writable: ctx.hosts_writable(),
                 extension_only_rules: engine.has_extension_only_rules(),
+                app_usage_measurable: focuser_common::session::app_usage_measurable(),
             }))
         }
 

--- a/crates/focuser-common/src/lib.rs
+++ b/crates/focuser-common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod ipc;
 pub mod pomodoro;
 pub mod process;
 pub mod schedule;
+pub mod session;
 pub mod types;
 pub mod uninstall;
 

--- a/crates/focuser-common/src/process.rs
+++ b/crates/focuser-common/src/process.rs
@@ -55,6 +55,37 @@ pub fn cmdline(pid: u32) -> Option<String> {
     imp::cmdline(pid)
 }
 
+/// The name [`list`] would report for the program at `path`.
+///
+/// A rule stores a name and blocking compares it against a running process, so
+/// picking a file from disk has to land on the same string the OS will hand
+/// back later. Each platform mangles it differently and none of them is the
+/// plain file name.
+pub fn name_for_path(path: &str) -> String {
+    imp::name_for_path(path)
+}
+
+/// The name [`list`] would report for one running process, without listing
+/// them all.
+///
+/// The foreground watcher knows a pid and needs the name a rule is written
+/// against. Going through the same per-OS source as [`list`] is what keeps an
+/// allowance and a block agreeing about what the app is called.
+#[cfg(not(windows))]
+pub fn name_for_pid(pid: u32) -> Option<String> {
+    imp::name_for_pid(pid)
+}
+
+/// The trailing path component, for the platforms where that is the whole job.
+fn file_name(path: &str) -> String {
+    let trimmed = path.trim_end_matches(['/', '\\']);
+    trimmed
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(trimmed)
+        .to_string()
+}
+
 #[cfg(windows)]
 mod imp {
     use super::Process;
@@ -136,6 +167,12 @@ mod imp {
             killed
         }
     }
+
+    /// `szExeFile` is the file name, extension and all, so there is nothing to
+    /// resolve here.
+    pub fn name_for_path(path: &str) -> String {
+        super::file_name(path)
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -187,9 +224,79 @@ mod imp {
         super::unix_terminate(pid)
     }
 
+    /// `ps comm=` reports the binary *inside* the bundle, so picking
+    /// `Google Chrome.app` has to resolve to `Google Chrome`. The name is
+    /// usually the bundle's, but `CFBundleExecutable` is the only place that
+    /// actually says so.
+    pub fn name_for_path(path: &str) -> String {
+        let trimmed = path.trim_end_matches('/');
+        if !trimmed.ends_with(".app") {
+            return super::file_name(trimmed);
+        }
+
+        let bundle = std::path::Path::new(trimmed);
+        declared_executable(&bundle.join("Contents/Info.plist"))
+            .unwrap_or_else(|| super::file_name(trimmed.trim_end_matches(".app")))
+    }
+
+    /// `ps -p` rather than a full sweep: the caller already knows the pid and
+    /// runs on a timer.
+    pub fn name_for_pid(pid: u32) -> Option<String> {
+        let output = std::process::Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "comm="])
+            .output()
+            .ok()?;
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        (!path.is_empty()).then(|| super::file_name(&path))
+    }
+
+    fn declared_executable(info_plist: &std::path::Path) -> Option<String> {
+        let value = plist::Value::from_file(info_plist).ok()?;
+        let name = value
+            .as_dictionary()?
+            .get("CFBundleExecutable")?
+            .as_string()?
+            .trim()
+            .to_string();
+        (!name.is_empty()).then_some(name)
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
+
+        #[test]
+        fn a_bundle_resolves_to_its_declared_executable() {
+            let dir = tempfile::tempdir().unwrap();
+            let bundle = dir.path().join("Google Chrome.app");
+            let contents = bundle.join("Contents");
+            std::fs::create_dir_all(&contents).unwrap();
+            std::fs::write(
+                contents.join("Info.plist"),
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>Google Chrome</string>
+</dict></plist>"#,
+            )
+            .unwrap();
+
+            let name = name_for_path(bundle.to_str().unwrap());
+            assert_eq!(name, "Google Chrome");
+        }
+
+        #[test]
+        fn a_bundle_without_a_plist_falls_back_to_its_own_name() {
+            let dir = tempfile::tempdir().unwrap();
+            let bundle = dir.path().join("Slack.app");
+            std::fs::create_dir_all(&bundle).unwrap();
+            assert_eq!(name_for_path(bundle.to_str().unwrap()), "Slack");
+        }
+
+        #[test]
+        fn a_bare_binary_keeps_its_file_name() {
+            assert_eq!(name_for_path("/usr/local/bin/node"), "node");
+        }
 
         #[test]
         fn a_ps_row_yields_the_executable_basename() {
@@ -250,6 +357,53 @@ mod imp {
 
     pub fn terminate(pid: u32) -> bool {
         super::unix_terminate(pid)
+    }
+
+    /// The kernel stores `comm` in 16 bytes including the terminator, so
+    /// `list` reports at most 15 characters. A rule holding the full file name
+    /// of a longer binary would never match a running one.
+    pub const COMM_LEN: usize = 15;
+
+    pub fn name_for_path(path: &str) -> String {
+        truncate_to_comm(&super::file_name(path))
+    }
+
+    /// Straight from `comm`, the same file `list` reads, so no truncation is
+    /// needed here — the kernel has already done it.
+    pub fn name_for_pid(pid: u32) -> Option<String> {
+        let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
+        let name = comm.trim();
+        (!name.is_empty()).then(|| name.to_string())
+    }
+
+    fn truncate_to_comm(name: &str) -> String {
+        match name.char_indices().nth(COMM_LEN) {
+            Some((cut, _)) => name[..cut].to_string(),
+            None => name.to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn a_short_name_is_left_alone() {
+            assert_eq!(name_for_path("/usr/bin/firefox"), "firefox");
+        }
+
+        #[test]
+        fn a_long_name_is_cut_where_the_kernel_cuts_it() {
+            let name = name_for_path("/opt/bin/some-very-long-binary");
+            assert_eq!(name, "some-very-long-");
+            assert_eq!(name.chars().count(), COMM_LEN);
+        }
+
+        #[test]
+        fn truncation_never_splits_a_character() {
+            let cut = truncate_to_comm("ααααααααααααααααα");
+            assert_eq!(cut.chars().count(), COMM_LEN);
+        }
     }
 }
 

--- a/crates/focuser-common/src/session.rs
+++ b/crates/focuser-common/src/session.rs
@@ -1,0 +1,46 @@
+//! What the desktop session will tell us about itself.
+//!
+//! Only one question so far, and it has an awkward answer on one platform.
+
+/// Can this machine tell us which application is in front?
+///
+/// App allowances count down by sampling the focused window, so where the
+/// answer is no, an app allowance can never move and never trigger a block.
+///
+/// Wayland is the no. It has no protocol for "which window is focused" — that
+/// was left out deliberately, so one app cannot watch another. GNOME needs a
+/// shell extension and KDE exposes nothing public, so there is no portable
+/// implementation to write. Windows, macOS and X11 all answer fine.
+///
+/// The app asks this so it can say so on the Allowances page rather than
+/// leaving someone staring at a timer that never moves.
+pub fn app_usage_measurable() -> bool {
+    !is_wayland()
+}
+
+fn is_wayland() -> bool {
+    if !cfg!(target_os = "linux") {
+        return false;
+    }
+    let session = std::env::var("XDG_SESSION_TYPE").unwrap_or_default();
+    session.eq_ignore_ascii_case("wayland") || std::env::var_os("WAYLAND_DISPLAY").is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_platform_but_wayland_can_measure() {
+        // On CI this runs under Windows, macOS and X11-less Linux containers
+        // alike; only a real Wayland session should answer false.
+        assert_eq!(app_usage_measurable(), !is_wayland());
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn wayland_is_a_linux_only_concern() {
+        assert!(!is_wayland());
+        assert!(app_usage_measurable());
+    }
+}

--- a/crates/focuser-ui/Cargo.toml
+++ b/crates/focuser-ui/Cargo.toml
@@ -42,3 +42,23 @@ windows = { version = "0.58", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",
 ] }
+
+# Which app is in front, and how long the user has been away. Versions match
+# what Tauri already pulls in, so this adds no second copy of objc2.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.3.2", default-features = false, features = [
+    "std",
+    "libc",
+    "NSWorkspace",
+    "NSRunningApplication",
+] }
+objc2-core-graphics = { version = "0.3.2", default-features = false, features = [
+    "std",
+    "CGEventSource",
+    "CGEventTypes",
+] }
+
+# Pure Rust, so packagers gain no new system dependency: it speaks the X11
+# protocol over the socket rather than linking libX11.
+[target.'cfg(target_os = "linux")'.dependencies]
+x11rb = { version = "0.14", features = ["screensaver"] }

--- a/crates/focuser-ui/frontend/src/bindings.ts
+++ b/crates/focuser-ui/frontend/src/bindings.ts
@@ -141,6 +141,11 @@ export type BlockingHealth = {
 	 *  enforce those; a hosts file has no way to express them.
 	 */
 	extension_only_rules: boolean,
+	/**
+	 *  This session can report which app is in front, so app allowances can
+	 *  count down. False on Wayland, which has no such protocol.
+	 */
+	app_usage_measurable: boolean,
 };
 
 export type BreakConfig = 

--- a/crates/focuser-ui/frontend/src/routes/allowances.tsx
+++ b/crates/focuser-ui/frontend/src/routes/allowances.tsx
@@ -15,6 +15,7 @@ import { TargetIcon } from "@/components/ui/target-icon";
 import { Tooltip } from "@/components/ui/tooltip";
 import {
   useAllowances,
+  useBlockingHealth,
   useBrowserStatus,
   useCreateAllowance,
   useDeleteAllowance,
@@ -40,6 +41,15 @@ export function Allowances() {
   const hasWebsiteAllowance = (allowances.data ?? []).some(
     (a) => a.allowance.target.kind === "Domain",
   );
+
+  // App time comes from sampling the focused window, which Wayland does not
+  // let anyone ask about. Same rule as above: say so rather than show a timer
+  // that will never move.
+  const health = useBlockingHealth();
+  const hasAppAllowance = (allowances.data ?? []).some(
+    (a) => a.allowance.target.kind === "AppExecutable",
+  );
+  const appTimingBlind = hasAppAllowance && health.data?.app_usage_measurable === false;
 
   const [kind, setKind] = useState<(typeof KINDS)[number]["value"]>("Domain");
   const [value, setValue] = useState("");
@@ -74,6 +84,20 @@ export function Allowances() {
             Only the extension can see which tab is open, so without it the timer never starts.
             Those sites stay blocked in the meantime — an allowance that cannot be measured would
             otherwise be an unlimited pass. Install it from Settings.
+          </p>
+        </Card>
+      )}
+
+      {appTimingBlind && (
+        <Card className="mb-6 border-warning/40" padding="md">
+          <p className="flex items-center gap-2 font-medium text-sm text-warning">
+            <TriangleAlert aria-hidden className="size-4" />
+            Application allowances cannot be measured on Wayland
+          </p>
+          <p className="mt-1 text-muted-foreground text-sm">
+            Wayland has no way for one program to ask which window is in front, so the timer never
+            starts. Those apps stay blocked in the meantime. Logging in with an Xorg session makes
+            it work. Website allowances are unaffected.
           </p>
         </Card>
       )}

--- a/crates/focuser-ui/frontend/src/routes/apps.tsx
+++ b/crates/focuser-ui/frontend/src/routes/apps.tsx
@@ -12,11 +12,43 @@ import { useAddAppRule, useAppIcons, useBlockLists, useRemoveAppRule } from "@/l
 import { APP_KINDS, type AppKind, appRule, describeApp } from "@/lib/match-types";
 import { isTauri, pickApplication } from "@/lib/native";
 
-const PLACEHOLDERS: Record<AppKind, string> = {
-  ExecutableName: "discord.exe",
-  ExecutablePath: "C:\\Program Files\\Steam\\steam.exe",
-  WindowTitle: "Solitaire",
+/**
+ * Examples in the shape this machine actually reports.
+ *
+ * A rule is compared against a running process, and the three platforms name
+ * those differently: `steam.exe` on Windows, `Steam` on macOS, `steam` on
+ * Linux. Showing a Windows example to a Linux user invites a rule that can
+ * never match.
+ *
+ * Read off the user agent rather than a Tauri plugin: this only picks example
+ * text, and the preview harness gets it right for free.
+ */
+const EXAMPLES: Record<"windows" | "macos" | "linux", Record<AppKind, string>> = {
+  windows: {
+    ExecutableName: "discord.exe",
+    ExecutablePath: "C:\\Program Files\\Steam\\steam.exe",
+    WindowTitle: "Solitaire",
+  },
+  macos: {
+    ExecutableName: "Discord",
+    ExecutablePath: "/Applications/Steam.app",
+    WindowTitle: "Solitaire",
+  },
+  linux: {
+    ExecutableName: "discord",
+    ExecutablePath: "/usr/bin/steam",
+    WindowTitle: "Solitaire",
+  },
 };
+
+function hostPlatform(): keyof typeof EXAMPLES {
+  const agent = typeof navigator === "undefined" ? "" : navigator.userAgent;
+  if (agent.includes("Mac")) return "macos";
+  if (agent.includes("Windows")) return "windows";
+  return "linux";
+}
+
+const PLACEHOLDERS = EXAMPLES[hostPlatform()];
 
 export function Apps() {
   const lists = useBlockLists();
@@ -102,7 +134,7 @@ export function Apps() {
               <EmptyState
                 icon={<AppWindow />}
                 title="No applications blocked"
-                description="Add an executable name like discord.exe, or browse for one on disk."
+                description={`Add an executable name like ${PLACEHOLDERS.ExecutableName}, or browse for one on disk.`}
               />
             ) : (
               <AppRules

--- a/crates/focuser-ui/src/foreground_watcher.rs
+++ b/crates/focuser-ui/src/foreground_watcher.rs
@@ -78,9 +78,13 @@ fn foreground_app() -> Option<ForegroundSample> {
     {
         win::foreground_app()
     }
-    #[cfg(not(windows))]
+    #[cfg(target_os = "macos")]
     {
-        None
+        mac::foreground_app()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        linux::foreground_app()
     }
 }
 
@@ -91,9 +95,13 @@ fn user_idle_seconds() -> Option<u32> {
     {
         win::user_idle_seconds()
     }
-    #[cfg(not(windows))]
+    #[cfg(target_os = "macos")]
     {
-        Some(0)
+        mac::user_idle_seconds()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        linux::user_idle_seconds()
     }
 }
 
@@ -203,5 +211,118 @@ mod win {
         fn file_name_handles_empty() {
             assert_eq!(file_name(""), "");
         }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod mac {
+    use super::ForegroundSample;
+    use objc2_app_kit::NSWorkspace;
+    use objc2_core_graphics::{CGEventSource, CGEventSourceStateID, CGEventType};
+
+    pub fn foreground_app() -> Option<ForegroundSample> {
+        let app = NSWorkspace::sharedWorkspace().frontmostApplication()?;
+        let pid = app.processIdentifier();
+        // AppKit reports -1 for an application that has no process.
+        if pid <= 0 {
+            return None;
+        }
+        let pid = pid as u32;
+
+        // Resolved through `process`, not from the bundle name, so the string
+        // matches what a rule is compared against.
+        let exe_name = focuser_common::process::name_for_pid(pid)?;
+        Some(ForegroundSample {
+            exe_name,
+            is_self: pid == std::process::id(),
+        })
+    }
+
+    /// `kCGAnyInputEventType` is `~0` and has no generated constant, so the
+    /// newtype is built from the value the header defines.
+    const ANY_INPUT_EVENT: CGEventType = CGEventType(u32::MAX);
+
+    pub fn user_idle_seconds() -> Option<u32> {
+        let seconds = CGEventSource::seconds_since_last_event_type(
+            CGEventSourceStateID::CombinedSessionState,
+            ANY_INPUT_EVENT,
+        );
+        // A negative or absurd reading means the API could not answer.
+        (seconds.is_finite() && seconds >= 0.0).then_some(seconds as u32)
+    }
+}
+
+/// X11 only, and deliberately so.
+///
+/// Wayland has no protocol for "which window is focused" — it was left out on
+/// purpose, so that one app cannot watch another. GNOME needs a shell
+/// extension and KDE offers nothing public, so there is no portable answer to
+/// implement. Under Wayland this reports nothing rather than reporting
+/// something wrong, and `session::app_usage_measurable` lets the app say so
+/// instead of leaving the user wondering why a timer never moves.
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::ForegroundSample;
+    use x11rb::connection::Connection;
+    use x11rb::protocol::screensaver::ConnectionExt as _;
+    use x11rb::protocol::xproto::{AtomEnum, ConnectionExt as _};
+    use x11rb::rust_connection::RustConnection;
+
+    /// A connection per tick. The handshake is a local socket round trip every
+    /// five seconds, which is cheaper than holding one open across a suspend
+    /// or an X server restart and having to notice it died.
+    fn connect() -> Option<(RustConnection, u32)> {
+        if !focuser_common::session::app_usage_measurable() {
+            return None;
+        }
+        let (conn, screen) = x11rb::connect(None).ok()?;
+        let root = conn.setup().roots.get(screen)?.root;
+        Some((conn, root))
+    }
+
+    fn atom(conn: &RustConnection, name: &[u8]) -> Option<u32> {
+        Some(conn.intern_atom(false, name).ok()?.reply().ok()?.atom)
+    }
+
+    /// First 32-bit word of a window property, which is all these two hold.
+    fn first_word(
+        conn: &RustConnection,
+        window: u32,
+        property: u32,
+        kind: AtomEnum,
+    ) -> Option<u32> {
+        conn.get_property(false, window, property, kind, 0, 1)
+            .ok()?
+            .reply()
+            .ok()?
+            .value32()?
+            .next()
+    }
+
+    pub fn foreground_app() -> Option<ForegroundSample> {
+        let (conn, root) = connect()?;
+
+        let active = atom(&conn, b"_NET_ACTIVE_WINDOW")?;
+        let window = first_word(&conn, root, active, AtomEnum::WINDOW)?;
+        if window == 0 {
+            return None;
+        }
+
+        // _NET_WM_PID is a convention, not a guarantee. A window without one
+        // simply does not get counted.
+        let wm_pid = atom(&conn, b"_NET_WM_PID")?;
+        let pid = first_word(&conn, window, wm_pid, AtomEnum::CARDINAL)?;
+
+        let exe_name = focuser_common::process::name_for_pid(pid)?;
+        Some(ForegroundSample {
+            exe_name,
+            is_self: pid == std::process::id(),
+        })
+    }
+
+    pub fn user_idle_seconds() -> Option<u32> {
+        let (conn, root) = connect()?;
+        let info = conn.screensaver_query_info(root).ok()?.reply().ok()?;
+        Some(info.ms_since_user_input / 1000)
     }
 }

--- a/crates/focuser-ui/src/native.rs
+++ b/crates/focuser-ui/src/native.rs
@@ -8,31 +8,29 @@
 
 use tauri_plugin_updater::UpdaterExt;
 
-/// Pick an executable to block. Returns its file name, which is what an
-/// `ExecutableName` rule matches on.
-#[tauri::command]
+/// Pick an executable to block. Returns the name an `ExecutableName` rule
+/// matches on, which is not always the file name — see `process::name_for_path`.
+///
+/// `(async)` is load-bearing. The plugin opens the dialog with
+/// `run_on_main_thread`, so waiting for it *from* the main thread deadlocks and
+/// the window hangs. That is what made Browse unusable on Linux.
+#[tauri::command(async)]
 pub fn pick_app_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     use tauri_plugin_dialog::DialogExt;
 
-    let (tx, rx) = std::sync::mpsc::channel();
+    let dialog = app.dialog().file().set_title("Select Application to Block");
 
-    app.dialog()
-        .file()
-        .set_title("Select Application to Block")
-        .add_filter("Executables", &["exe", "app", "sh", "AppImage"])
-        .add_filter("All Files", &["*"])
-        .pick_file(move |path| {
-            let result = path.map(|p| {
-                let path_str = p.to_string();
-                std::path::Path::new(&path_str)
-                    .file_name()
-                    .map(|f| f.to_string_lossy().to_string())
-                    .unwrap_or(path_str)
-            });
-            let _ = tx.send(result);
-        });
+    // Filters only where an executable actually carries an extension. rfd turns
+    // every filter entry into `*.ext`, so on Linux even an "All files" filter
+    // becomes `*.*` and hides every extensionless binary in /usr/bin.
+    #[cfg(windows)]
+    let dialog = dialog.add_filter("Programs", &["exe", "com", "bat", "cmd"]);
+    #[cfg(target_os = "macos")]
+    let dialog = dialog.add_filter("Applications", &["app"]);
 
-    rx.recv().map_err(|e| format!("Dialog error: {e}"))
+    Ok(dialog
+        .blocking_pick_file()
+        .map(|picked| focuser_common::process::name_for_path(&picked.to_string())))
 }
 
 /// Pick a Focuser configuration file and return its contents.


### PR DESCRIPTION
Fixes #6, and fixes app allowances never counting down anywhere except Windows.

## The file picker hung on Linux (#6)

`pick_app_file` was a plain `#[tauri::command]`, so it ran on the main thread and then blocked on a channel waiting for the dialog. The plugin opens that dialog with `run_on_main_thread` — the very thread the command had just blocked. The plugin's own docs say the blocking variants "should *NOT* be used when running on the main thread context"; this was exactly that mistake.

`(async)` moves it to the blocking pool, and `blocking_pick_file` replaces the hand-rolled channel.

The same command also filtered on `exe`, `app`, `sh`, `AppImage`, plus an "All files" entry of `*`. rfd builds GTK filters as `*.{ext}` ([`dialog_ffi.rs:52`](https://docs.rs/crate/rfd/0.16.0/source/src/backend/gtk3/file_dialog/dialog_ffi.rs)), so `*` becomes `*.*` and hid every extensionless binary in `/usr/bin` — including under "All files". Filters now exist only where executables actually carry an extension.

## App allowances never counted down off Windows

`foreground_app` returned `None` on every other platform, so nothing fed app usage and no app allowance could move or trigger a block. The watcher's own doc comment described this gap.

- **macOS** — `NSWorkspace::sharedWorkspace().frontmostApplication()`, and `CGEventSource::seconds_since_last_event_type` for idle. Both from the objc2 crates Tauri already pulls in, pinned to the versions already in the lockfile so there is no second copy.
- **Linux** — `_NET_ACTIVE_WINDOW` then `_NET_WM_PID` via x11rb, which speaks the protocol over the socket instead of linking libX11, so packagers gain no new system dependency. Idle comes from the screensaver extension.

Both resolve the pid through a new `process::name_for_pid`, the same per-OS source `process::list` already uses, because a rule is compared against a listed process and the two names have to be the same string.

`name_for_path` is the matching half for the picker, and it is not the file name on either Unix:

- a macOS `.app` is a bundle whose binary is named by `CFBundleExecutable`, so `Google Chrome.app` has to resolve to `Google Chrome`
- Linux `comm` is capped at 15 characters by the kernel, so longer names are truncated identically rather than never matching

## Wayland

Wayland has no protocol for which window is focused — omitted deliberately, so one app cannot watch another. There is nothing portable to implement. `session::app_usage_measurable` reports it and the Allowances page warns, mirroring the existing warning for website allowances with no extension.

## Verification

Windows: `fmt`, `clippy -D warnings` and the full test suite pass locally, plus new tests for bundle resolution and `comm` truncation.

**macOS and Linux cannot be compiled from a Windows machine**, so this PR exists to have CI do it. Please don't merge until the Ubuntu and macOS jobs are green.